### PR TITLE
feat(hooks): add tool permission approval via Telegram

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,4 @@ npm run test:watch
 ## License
 
 MIT
+

--- a/docs/user-stories/send-pictures-to-claude.md
+++ b/docs/user-stories/send-pictures-to-claude.md
@@ -1,0 +1,147 @@
+# User Story: Send Pictures to Claude
+
+**Status:** Proposed
+**Priority:** Medium
+**Created:** 2026-02-15
+**Effort:** M (4-8 hours)
+
+---
+
+## User Story
+
+**As a** user interacting with Claude via Telegram
+**I want to** send pictures/photos to Claude
+**So that** I can get Claude to analyze, describe, or work with visual content
+
+---
+
+## Acceptance Criteria
+
+- [ ] User can send a photo message to the Telegram bot
+- [ ] Photo is received and processed by the webhook
+- [ ] Photo is downloaded from Telegram servers
+- [ ] Photo is saved to a temporary location accessible by Claude
+- [ ] Claude receives a message with the image context (file path or reference)
+- [ ] Claude can analyze and respond to the image content
+- [ ] User receives Claude's response about the image in Telegram
+
+---
+
+## Technical Design
+
+### Flow
+
+```
+Telegram (photo) → Webhook → Download Photo → Save to workspace → Inject to tmux → Claude
+                                                                              ↓
+Telegram ← Stop Hook ← Claude's response ←─────────────────────────────────────┘
+```
+
+### Implementation Steps
+
+#### 1. Handle Photo Messages in Webhook
+
+Update `src/server/routes/telegram.ts` to handle `message.photo`:
+
+```typescript
+// Telegram sends multiple photo sizes, get the largest one
+if (message.photo && message.photo.length > 0) {
+  const largestPhoto = message.photo[message.photo.length - 1];
+  await handlePhotoMessage(chat.id, largestPhoto, text);
+}
+```
+
+#### 2. Download Photo from Telegram
+
+Add to `src/telegram/client.ts`:
+
+```typescript
+async getFile(fileId: string): Promise<{ file_path: string }> {
+  const url = `https://api.telegram.org/bot${this.token}/getFile`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ file_id: fileId }),
+  });
+  return response.json();
+}
+
+async downloadFile(filePath: string): Promise<Buffer> {
+  const url = `https://api.telegram.org/file/bot${this.token}/${filePath}`;
+  const response = await fetch(url);
+  return Buffer.from(await response.arrayBuffer());
+}
+```
+
+#### 3. Save Photo to Workspace
+
+Save incoming photos to a dedicated folder:
+
+```typescript
+const PHOTOS_DIR = join(WORKSPACE_DIR, 'photos');
+
+async function savePhoto(buffer: Buffer, fileId: string): Promise<string> {
+  await ensureDir(PHOTOS_DIR);
+  const filename = `${fileId}.jpg`;
+  const filepath = join(PHOTOS_DIR, filename);
+  await writeFile(filepath, buffer);
+  return filepath;
+}
+```
+
+#### 4. Inject Photo Reference to Claude
+
+When a photo is received, inject a message like:
+
+```
+User sent an image. The image is saved at: /path/to/workspace/photos/xxx.jpg
+Please analyze this image.
+```
+
+Or use Claude's image analysis capability if supported via CLI.
+
+---
+
+## Edge Cases
+
+- **Multiple photos**: Telegram albums send multiple messages. Consider grouping.
+- **Large files**: Check file size limits, consider compression.
+- **Unsupported formats**: Handle non-JPG formats (PNG, WEBP).
+- **Caption text**: Combine photo with text caption if provided.
+- **Cleanup**: Implement periodic cleanup of old photos.
+
+---
+
+## Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PHOTOS_DIR` | Directory to save incoming photos | `workspace/photos` |
+| `MAX_PHOTO_SIZE` | Maximum photo size in bytes | `10MB` |
+| `PHOTO_CLEANUP_AGE` | Age in hours before cleanup | `24` |
+
+---
+
+## Testing
+
+1. Send single photo to bot
+2. Send photo with caption
+3. Send multiple photos (album)
+4. Send unsupported format
+5. Verify photo cleanup works
+
+---
+
+## Dependencies
+
+- Telegram Bot API `getFile` and file download endpoints
+- File system access for saving photos
+- Claude Code ability to reference local files
+
+---
+
+## Questions
+
+- Should photos be saved permanently or cleaned up after processing?
+- Does Claude Code CLI support image analysis from local file paths?
+- Should we support sending images back from Claude to Telegram?

--- a/hooks/permission-request.mjs
+++ b/hooks/permission-request.mjs
@@ -1,0 +1,543 @@
+#!/usr/bin/env node
+
+/**
+ * Claude Code PreToolUse Hook - Permission Request via Telegram
+ *
+ * This script runs before Claude uses a tool that requires permission.
+ * It sends a request to Telegram with Approve/Deny buttons and waits
+ * for the user's response.
+ *
+ * Usage: Configured in Claude Code settings as a PreToolUse hook
+ *
+ * Exit codes:
+ *   0 - Approved (tool can proceed)
+ *   2 - Denied (tool should not proceed)
+ *   1 - Error or timeout (tool should not proceed)
+ */
+
+import { readFile, writeFile, unlink, mkdir, rename, readdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join, basename, dirname } from 'path';
+import { homedir, tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+
+// Get the directory of this script for finding .env
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PROJECT_ROOT = join(__dirname, '..');
+
+// Configuration
+const STATE_DIR = process.env.STATE_DIR || join(homedir(), '.claude');
+const PERMISSION_DIR = join(STATE_DIR, 'permissions');
+const PERMISSION_INDEX_FILE = join(STATE_DIR, 'permission_index');
+const TELEGRAM_CHAT_ID_FILE = join(STATE_DIR, 'telegram_chat_id');
+const PERMISSION_RULES_FILE = join(STATE_DIR, 'tool_permissions.json');
+const TIMEOUT_MS = parseInt(process.env.PERMISSION_TIMEOUT_MS || '300000', 10); // 5 min default
+const POLL_INTERVAL_MS = 500;
+
+// Token will be loaded asynchronously
+let TELEGRAM_BOT_TOKEN = null;
+
+/**
+ * Read token from .env file
+ */
+async function getTokenFromEnv() {
+  const envPath = join(PROJECT_ROOT, '.env');
+  if (existsSync(envPath)) {
+    const content = await readFile(envPath, 'utf-8');
+    const match = content.match(/^TELEGRAM_BOT_TOKEN=(.+)$/m);
+    if (match) {
+      return match[1].trim();
+    }
+  }
+  return process.env.TELEGRAM_BOT_TOKEN;
+}
+
+/**
+ * Atomic file write
+ */
+async function atomicWrite(filePath, content) {
+  const tempPath = join(tmpdir(), `${basename(filePath)}.${Date.now()}.tmp`);
+  await writeFile(tempPath, content, 'utf-8');
+  await rename(tempPath, filePath);
+}
+
+/**
+ * Read file safely
+ */
+async function safeRead(filePath) {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+  try {
+    return await readFile(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ensure directory exists
+ */
+async function ensureDir(dir) {
+  if (!existsSync(dir)) {
+    await mkdir(dir, { recursive: true });
+  }
+}
+
+/**
+ * Simple glob pattern matcher (supports **, *, ?)
+ */
+function matchPattern(pattern, str) {
+  // Convert glob to regex
+  let regex = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')  // Escape special regex chars
+    .replace(/\*\*/g, '<<DOUBLE_STAR>>')    // Temp placeholder
+    .replace(/\*/g, '[^/]*')                // * matches anything except /
+    .replace(/<<DOUBLE_STAR>>/g, '.*')      // ** matches anything including /
+    .replace(/\?/g, '[^/]');                // ? matches single char except /
+  regex = '^' + regex + '$';
+  return new RegExp(regex).test(str);
+}
+
+/**
+ * Load permission rules from config file
+ */
+async function loadPermissionRules() {
+  const content = await safeRead(PERMISSION_RULES_FILE);
+  if (!content) {
+    return { rules: [], defaultAction: 'ask' };
+  }
+  try {
+    const config = JSON.parse(content);
+    return {
+      rules: config.rules || [],
+      defaultAction: config.defaultAction || 'ask'
+    };
+  } catch {
+    return { rules: [], defaultAction: 'ask' };
+  }
+}
+
+/**
+ * Check if tool use matches a rule
+ */
+function matchesRule(rule, toolName, toolInput) {
+  // Check tool match
+  if (rule.tools && !rule.tools.includes(toolName)) {
+    return false;
+  }
+
+  // Check path match (for Write/Edit)
+  if (rule.paths) {
+    const targetPath = toolInput.file_path || toolInput.path;
+    if (!targetPath) return false;
+
+    const matchesPath = rule.paths.some(pattern => matchPattern(pattern, targetPath));
+    if (!matchesPath) return false;
+  }
+
+  // Check pattern match (for Bash)
+  if (rule.patterns) {
+    const command = toolInput.command || '';
+    const matchesPattern = rule.patterns.some(pattern => {
+      // Simple substring match for bash patterns
+      return command.includes(pattern);
+    });
+    if (!matchesPattern) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Check permission rules and return action
+ */
+function checkPermissionRules(rulesConfig, toolName, toolInput) {
+  // Check rules in order (first match wins)
+  for (const rule of rulesConfig.rules) {
+    if (matchesRule(rule, toolName, toolInput)) {
+      return rule.action;
+    }
+  }
+  // Return default action if no rule matches
+  return rulesConfig.defaultAction || 'ask';
+}
+
+/**
+ * Read chat ID from state file
+ */
+async function getChatId() {
+  const content = await safeRead(TELEGRAM_CHAT_ID_FILE);
+  if (!content) {
+    return null;
+  }
+  try {
+    const state = JSON.parse(content);
+    return state.chatId;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Generate unique request ID
+ */
+async function generateRequestId() {
+  await ensureDir(STATE_DIR);
+
+  let index = { lastId: 0 };
+  const content = await safeRead(PERMISSION_INDEX_FILE);
+  if (content) {
+    try {
+      index = JSON.parse(content);
+    } catch {
+      // Use default
+    }
+  }
+
+  index.lastId += 1;
+  await atomicWrite(PERMISSION_INDEX_FILE, JSON.stringify(index));
+
+  const timestamp = Date.now().toString(36);
+  return `perm_${timestamp}_${index.lastId}`;
+}
+
+/**
+ * Format tool input for display
+ */
+function formatToolInput(toolName, input, maxLength = 500) {
+  let display = '';
+
+  switch (toolName) {
+    case 'Write':
+    case 'Edit':
+      display = `file: ${input.file_path || 'unknown'}`;
+      if (input.content) {
+        const content = String(input.content);
+        if (content.length > 100) {
+          display += `\ncontent: ${content.slice(0, 100)}...`;
+        } else {
+          display += `\ncontent: ${content}`;
+        }
+      }
+      break;
+
+    case 'Bash':
+      display = `command: ${input.command || 'unknown'}`;
+      break;
+
+    default:
+      const entries = Object.entries(input || {});
+      if (entries.length === 0) {
+        display = '(no parameters)';
+      } else {
+        display = entries
+          .map(([key, value]) => {
+            const strValue = String(value);
+            if (strValue.length > 100) {
+              return `${key}: ${strValue.slice(0, 100)}...`;
+            }
+            return `${key}: ${strValue}`;
+          })
+          .join('\n');
+      }
+  }
+
+  if (display.length > maxLength) {
+    display = display.slice(0, maxLength) + '...';
+  }
+
+  return display;
+}
+
+/**
+ * Escape special characters for Telegram MarkdownV2
+ */
+function escapeTelegram(text) {
+  return text.replace(/[_*[\]()~`>#+=|{}.!-]/g, '\\$&');
+}
+
+/**
+ * Escape for inline code
+ */
+function escapeCode(text) {
+  return text.replace(/[`\\.]/g, '\\$&');
+}
+
+/**
+ * Send permission request to Telegram with inline keyboard
+ */
+async function sendPermissionRequest(chatId, requestId, toolName, toolInput) {
+  if (!TELEGRAM_BOT_TOKEN) {
+    throw new Error('TELEGRAM_BOT_TOKEN not set');
+  }
+
+  const url = `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`;
+
+  const displayInput = formatToolInput(toolName, toolInput);
+  const text = `🔧 *Tool Permission Request*\n\n` +
+    `*Tool:* ${escapeTelegram(toolName)}\n` +
+    `*Parameters:*\n\`\`\`\n${escapeCode(displayInput)}\n\`\`\`\n\n` +
+    `_Waiting for your response\\.\\.\\._`;
+
+  const body = {
+    chat_id: chatId,
+    text,
+    parse_mode: 'MarkdownV2',
+    reply_markup: {
+      inline_keyboard: [
+        [
+          { text: '✅ Approve', callback_data: `approve:${requestId}` },
+          { text: '❌ Deny', callback_data: `deny:${requestId}` },
+        ],
+      ],
+    },
+  };
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  const data = await response.json();
+
+  if (!data.ok) {
+    throw new Error(`Telegram API error: ${data.description}`);
+  }
+
+  return data.result.message_id;
+}
+
+/**
+ * Save permission request to state file
+ */
+async function savePermissionRequest(request) {
+  await ensureDir(PERMISSION_DIR);
+  const filePath = join(PERMISSION_DIR, `${request.requestId}.json`);
+  await atomicWrite(filePath, JSON.stringify(request, null, 2));
+}
+
+/**
+ * Get permission request from state file
+ */
+async function getPermissionRequest(requestId) {
+  const filePath = join(PERMISSION_DIR, `${requestId}.json`);
+  const content = await safeRead(filePath);
+  if (!content) {
+    return null;
+  }
+  try {
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Update permission request
+ */
+async function updatePermissionRequest(requestId, updates) {
+  const request = await getPermissionRequest(requestId);
+  if (!request) return null;
+
+  const updated = { ...request, ...updates };
+  const filePath = join(PERMISSION_DIR, `${requestId}.json`);
+  await atomicWrite(filePath, JSON.stringify(updated, null, 2));
+  return updated;
+}
+
+/**
+ * Delete permission request
+ */
+async function deletePermissionRequest(requestId) {
+  const filePath = join(PERMISSION_DIR, `${requestId}.json`);
+  if (existsSync(filePath)) {
+    await unlink(filePath);
+  }
+}
+
+/**
+ * Update Telegram message to show timeout
+ */
+async function sendTimeoutMessage(chatId, messageId, toolName) {
+  if (!TELEGRAM_BOT_TOKEN) return;
+
+  const url = `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/editMessageText`;
+
+  const text = `🔧 *Tool Permission Request*\n\n` +
+    `*Tool:* ${escapeTelegram(toolName)}\n\n` +
+    `⏰ *TIMED OUT* \\- No response received`;
+
+  await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      chat_id: chatId,
+      message_id: messageId,
+      text,
+      parse_mode: 'MarkdownV2',
+    }),
+  }).catch(() => {}); // Ignore errors
+}
+
+/**
+ * Wait for permission response (polling)
+ */
+async function waitForResponse(requestId, timeoutMs, pollIntervalMs) {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    const request = await getPermissionRequest(requestId);
+
+    if (!request) {
+      return { approved: false, response: 'timeout' };
+    }
+
+    if (request.status === 'approved') {
+      await deletePermissionRequest(requestId);
+      return { approved: true, response: 'approve' };
+    }
+
+    if (request.status === 'denied') {
+      await deletePermissionRequest(requestId);
+      return { approved: false, response: 'deny' };
+    }
+
+    if (request.status === 'expired') {
+      await deletePermissionRequest(requestId);
+      return { approved: false, response: 'timeout' };
+    }
+
+    await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+  }
+
+  // Mark as expired
+  await updatePermissionRequest(requestId, { status: 'expired' });
+  return { approved: false, response: 'timeout' };
+}
+
+/**
+ * Main entry point
+ */
+async function main() {
+  const log = (msg) => {
+    const timestamp = new Date().toISOString();
+    console.error(`[${timestamp}] ${msg}`);
+  };
+
+  log('Permission hook triggered');
+
+  // Load token
+  TELEGRAM_BOT_TOKEN = await getTokenFromEnv();
+  if (!TELEGRAM_BOT_TOKEN) {
+    log('ERROR: TELEGRAM_BOT_TOKEN not found');
+    process.exit(1);
+  }
+
+  // Get chat ID
+  const chatId = await getChatId();
+  if (!chatId) {
+    log('ERROR: No chat ID available - send a message first to register chat');
+    process.exit(1);
+  }
+
+  // Read hook input from stdin
+  let hookInput = null;
+  try {
+    const stdin = [];
+    for await (const chunk of process.stdin) {
+      stdin.push(chunk);
+    }
+    const input = Buffer.concat(stdin).toString('utf-8');
+    log(`Received stdin (${input.length} bytes)`);
+    if (input) {
+      hookInput = JSON.parse(input);
+    }
+  } catch (err) {
+    log(`ERROR: Failed to parse stdin: ${err.message}`);
+    process.exit(1);
+  }
+
+  // Extract tool info
+  const toolName = hookInput?.tool_name || hookInput?.tool || 'Unknown';
+  const toolInput = hookInput?.tool_input || hookInput?.input || {};
+
+  log(`Tool: ${toolName}`);
+  log(`Input: ${JSON.stringify(toolInput).slice(0, 200)}...`);
+
+  // Check permission rules
+  const rulesConfig = await loadPermissionRules();
+  const action = checkPermissionRules(rulesConfig, toolName, toolInput);
+  log(`Rule action: ${action}`);
+
+  if (action === 'allow') {
+    log('Auto-approved by rule');
+    console.log(JSON.stringify({ decision: 'approve', reason: 'Matched allow rule' }));
+    process.exit(0);
+  }
+
+  if (action === 'deny') {
+    log('Auto-denied by rule');
+    console.log(JSON.stringify({ decision: 'block', reason: 'Matched deny rule' }));
+    process.exit(0);
+  }
+
+  // action === 'ask': proceed to Telegram approval
+
+  // Generate request ID
+  const requestId = await generateRequestId();
+  log(`Request ID: ${requestId}`);
+
+  // Save request to state
+  await savePermissionRequest({
+    requestId,
+    toolName,
+    toolInput,
+    chatId,
+    timestamp: Date.now(),
+    status: 'pending',
+  });
+
+  // Send to Telegram
+  let messageId;
+  try {
+    messageId = await sendPermissionRequest(chatId, requestId, toolName, toolInput);
+    log(`Message sent (ID: ${messageId})`);
+
+    // Update request with message ID
+    await updatePermissionRequest(requestId, { messageId });
+  } catch (err) {
+    log(`ERROR: Failed to send Telegram message: ${err.message}`);
+    await deletePermissionRequest(requestId);
+    process.exit(1);
+  }
+
+  // Wait for response
+  log(`Waiting for response (timeout: ${TIMEOUT_MS}ms)...`);
+  const result = await waitForResponse(requestId, TIMEOUT_MS, POLL_INTERVAL_MS);
+
+  if (result.response === 'timeout') {
+    log('Permission request timed out');
+    await sendTimeoutMessage(chatId, messageId, toolName);
+    await deletePermissionRequest(requestId);
+    console.log(JSON.stringify({ decision: 'block', reason: 'Permission request timed out' }));
+    process.exit(0);
+  }
+
+  if (result.approved) {
+    log('Permission APPROVED');
+    console.log(JSON.stringify({ decision: 'approve' }));
+    process.exit(0);
+  } else {
+    log('Permission DENIED');
+    console.log(JSON.stringify({ decision: 'block', reason: 'User denied permission' }));
+    process.exit(0);
+  }
+}
+
+main().catch((err) => {
+  console.error('Hook error:', err);
+  process.exit(1);
+});

--- a/src/state/permission.ts
+++ b/src/state/permission.ts
@@ -1,0 +1,358 @@
+/**
+ * Permission State Management Module
+ *
+ * Tracks pending tool permission requests for Telegram approval.
+ * Uses atomic writes for safety.
+ *
+ * Flow:
+ * 1. Hook script creates permission request → savePermissionRequest()
+ * 2. User approves/denies via Telegram → updatePermissionRequest()
+ * 3. Hook script polls for response → waitForPermissionResponse()
+ * 4. Response returned, state cleaned up → clearPermissionRequest()
+ */
+
+import { readFile, writeFile, unlink, mkdir, rename } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { homedir, tmpdir } from 'os';
+import { basename } from 'path';
+
+// File names
+const PERMISSION_DIR = 'permissions';
+const PERMISSION_INDEX_FILE = 'permission_index';
+
+// Types
+export type PermissionStatus = 'pending' | 'approved' | 'denied' | 'expired';
+
+export interface PermissionRequest {
+  requestId: string;
+  toolName: string;
+  toolInput: Record<string, unknown>;
+  chatId: number;
+  messageId?: number;
+  timestamp: number;
+  status: PermissionStatus;
+  response?: 'approve' | 'deny';
+  respondedAt?: number;
+}
+
+export interface PermissionIndex {
+  lastId: number;
+}
+
+// Get state directory
+function getStateDir(): string {
+  return process.env.STATE_DIR || join(homedir(), '.claude');
+}
+
+// Get permission directory
+function getPermissionDir(): string {
+  return join(getStateDir(), PERMISSION_DIR);
+}
+
+// Helper: Ensure directory exists
+async function ensureDir(dir: string): Promise<void> {
+  if (!existsSync(dir)) {
+    await mkdir(dir, { recursive: true });
+  }
+}
+
+// Helper: Atomic write
+async function atomicWrite(filePath: string, content: string): Promise<void> {
+  await ensureDir(join(filePath, '..'));
+  const tempPath = join(tmpdir(), `${basename(filePath)}.${Date.now()}.tmp`);
+  await writeFile(tempPath, content, 'utf-8');
+  await rename(tempPath, filePath);
+}
+
+// Helper: Read file safely
+async function safeRead(filePath: string): Promise<string | null> {
+  if (!existsSync(filePath)) {
+    return null;
+  }
+  try {
+    return await readFile(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+// Helper: Get permission file path
+function getPermissionFilePath(requestId: string): string {
+  return join(getPermissionDir(), `${requestId}.json`);
+}
+
+// Helper: Get index file path
+function getIndexFilePath(): string {
+  return join(getStateDir(), PERMISSION_INDEX_FILE);
+}
+
+/**
+ * Generate a unique request ID
+ */
+export async function generateRequestId(): Promise<string> {
+  await ensureDir(getStateDir());
+
+  const indexFile = getIndexFilePath();
+  let index: PermissionIndex = { lastId: 0 };
+
+  // Read current index
+  const content = await safeRead(indexFile);
+  if (content) {
+    try {
+      index = JSON.parse(content);
+    } catch {
+      // Use default
+    }
+  }
+
+  // Increment
+  index.lastId += 1;
+
+  // Save
+  await atomicWrite(indexFile, JSON.stringify(index));
+
+  // Generate ID with timestamp for uniqueness
+  const timestamp = Date.now().toString(36);
+  return `perm_${timestamp}_${index.lastId}`;
+}
+
+/**
+ * Save a new permission request
+ */
+export async function savePermissionRequest(request: Omit<PermissionRequest, 'requestId' | 'timestamp' | 'status'> & { requestId?: string }): Promise<PermissionRequest> {
+  await ensureDir(getPermissionDir());
+
+  const fullRequest: PermissionRequest = {
+    requestId: request.requestId || await generateRequestId(),
+    toolName: request.toolName,
+    toolInput: request.toolInput,
+    chatId: request.chatId,
+    messageId: request.messageId,
+    timestamp: Date.now(),
+    status: 'pending',
+  };
+
+  const filePath = getPermissionFilePath(fullRequest.requestId);
+  await atomicWrite(filePath, JSON.stringify(fullRequest, null, 2));
+
+  return fullRequest;
+}
+
+/**
+ * Get a permission request by ID
+ */
+export async function getPermissionRequest(requestId: string): Promise<PermissionRequest | null> {
+  const filePath = getPermissionFilePath(requestId);
+  const content = await safeRead(filePath);
+
+  if (!content) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Update permission request status
+ */
+export async function updatePermissionRequest(
+  requestId: string,
+  updates: Partial<Pick<PermissionRequest, 'status' | 'response' | 'respondedAt' | 'messageId'>>
+): Promise<PermissionRequest | null> {
+  const request = await getPermissionRequest(requestId);
+  if (!request) {
+    return null;
+  }
+
+  const updated: PermissionRequest = {
+    ...request,
+    ...updates,
+  };
+
+  const filePath = getPermissionFilePath(requestId);
+  await atomicWrite(filePath, JSON.stringify(updated, null, 2));
+
+  return updated;
+}
+
+/**
+ * Clear/delete a permission request
+ */
+export async function clearPermissionRequest(requestId: string): Promise<void> {
+  const filePath = getPermissionFilePath(requestId);
+  if (existsSync(filePath)) {
+    await unlink(filePath);
+  }
+}
+
+/**
+ * Wait for permission response (polling)
+ * Returns the response or null on timeout
+ */
+export async function waitForPermissionResponse(
+  requestId: string,
+  timeoutMs: number = 300000, // 5 minutes default
+  pollIntervalMs: number = 500
+): Promise<{ approved: boolean; response: 'approve' | 'deny' | 'timeout' }> {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    const request = await getPermissionRequest(requestId);
+
+    if (!request) {
+      // Request was deleted (shouldn't happen normally)
+      return { approved: false, response: 'timeout' };
+    }
+
+    if (request.status === 'approved') {
+      await clearPermissionRequest(requestId);
+      return { approved: true, response: 'approve' };
+    }
+
+    if (request.status === 'denied') {
+      await clearPermissionRequest(requestId);
+      return { approved: false, response: 'deny' };
+    }
+
+    if (request.status === 'expired') {
+      await clearPermissionRequest(requestId);
+      return { approved: false, response: 'timeout' };
+    }
+
+    // Wait before next poll
+    await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+  }
+
+  // Timeout - mark as expired
+  await updatePermissionRequest(requestId, { status: 'expired' });
+  return { approved: false, response: 'timeout' };
+}
+
+/**
+ * Get all pending permission requests (for status/cleanup)
+ */
+export async function getPendingPermissions(): Promise<PermissionRequest[]> {
+  const dir = getPermissionDir();
+  await ensureDir(dir);
+
+  const { readdir } = await import('fs/promises');
+  const files = await readdir(dir);
+
+  const pending: PermissionRequest[] = [];
+
+  for (const file of files) {
+    if (!file.endsWith('.json')) continue;
+
+    const content = await safeRead(join(dir, file));
+    if (content) {
+      try {
+        const request: PermissionRequest = JSON.parse(content);
+        if (request.status === 'pending') {
+          pending.push(request);
+        }
+      } catch {
+        // Skip invalid files
+      }
+    }
+  }
+
+  return pending;
+}
+
+/**
+ * Clean up expired permission requests
+ */
+export async function cleanupExpiredPermissions(timeoutMs: number = 300000): Promise<number> {
+  const dir = getPermissionDir();
+  await ensureDir(dir);
+
+  const { readdir } = await import('fs/promises');
+  const files = await readdir(dir);
+
+  let cleaned = 0;
+
+  for (const file of files) {
+    if (!file.endsWith('.json')) continue;
+
+    const content = await safeRead(join(dir, file));
+    if (content) {
+      try {
+        const request: PermissionRequest = JSON.parse(content);
+        const age = Date.now() - request.timestamp;
+
+        if (request.status === 'pending' && age > timeoutMs) {
+          await clearPermissionRequest(request.requestId);
+          cleaned++;
+        } else if (request.status !== 'pending') {
+          // Clean up resolved requests older than 1 hour
+          if (request.respondedAt && Date.now() - request.respondedAt > 3600000) {
+            await clearPermissionRequest(request.requestId);
+            cleaned++;
+          }
+        }
+      } catch {
+        // Skip invalid files
+      }
+    }
+  }
+
+  return cleaned;
+}
+
+/**
+ * Format tool input for display (truncate/redact sensitive data)
+ */
+export function formatToolInputForDisplay(
+  toolName: string,
+  input: Record<string, unknown>,
+  maxLength: number = 500
+): string {
+  let display = '';
+
+  switch (toolName) {
+    case 'Write':
+    case 'Edit':
+      display = `file: ${input.file_path || 'unknown'}`;
+      if (input.content) {
+        const content = String(input.content);
+        if (content.length > 100) {
+          display += `\ncontent: ${content.slice(0, 100)}...`;
+        } else {
+          display += `\ncontent: ${content}`;
+        }
+      }
+      break;
+
+    case 'Bash':
+      display = `command: ${input.command || 'unknown'}`;
+      break;
+
+    default:
+      // Generic formatting
+      const entries = Object.entries(input);
+      if (entries.length === 0) {
+        display = '(no parameters)';
+      } else {
+        display = entries
+          .map(([key, value]) => {
+            const strValue = String(value);
+            if (strValue.length > 100) {
+              return `${key}: ${strValue.slice(0, 100)}...`;
+            }
+            return `${key}: ${strValue}`;
+          })
+          .join('\n');
+      }
+  }
+
+  if (display.length > maxLength) {
+    display = display.slice(0, maxLength) + '...';
+  }
+
+  return display;
+}


### PR DESCRIPTION
## Summary

  - Add PreToolUse hook for requesting tool approvals via Telegram with inline keyboard buttons
  - Implement permission rules system for auto-approving safe paths (dev-workspace)
  - Add user story documentation for future send-pictures feature

  ## Changes

  - `hooks/permission-request.mjs` - Approval hook with Telegram integration
  - `src/server/routes/telegram.ts` - Callback query handling
  - `src/state/permission.ts` - Permission state management
  - `docs/user-stories/send-pictures-to-claude.md` - User story for image support

  ## Test Plan

  - [x] Send approval request to Telegram when editing sensitive file
  - [x] Auto-approve edits in dev-workspace without Telegram prompt
  - [x] Handle approve/deny callback from inline keyboard
  - [x] Timeout handling for unanswered requests